### PR TITLE
Fix: Add scope to package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ up to [v9.0.1](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v9.0.1).
 
 ## 0.0.1 - 5 February 2025
 
+- Add scope to package name ([PR 25](https://github.com/TechnologyEnhancedLearning/nhsuk-frontend-tel/pull/25)).
+
 - Pull changes in from upstream repo ([PR 24](https://github.com/TechnologyEnhancedLearning/nhsuk-frontend-tel/pull/24)).
 
 Initial setup and configuration

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nhse-tel-frontend",
+  "name": "@technology-enhanced-learning/nhse-tel-frontend",
   "version": "0.0.1",
   "description": "NHS England TEL frontend contains the code you need to start building user interfaces for NHS websites and services.",
   "engines": {


### PR DESCRIPTION
### Description
When creating the first release and hence what should be the first npm package, I was getting an error. I believe this is due to the scoping of the npm token to the technology-enhanced-learning organisation.
I have therefore changed the package name to include the scope. This appears to be the recommended approach.
So hopefully with this change, the npm package will now be created.

### Screenshots
n/a

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested  with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation
- [x] CHANGELOG entry
